### PR TITLE
Add stipend to Notable Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Access the built-in web dashboard at `http://localhost:18789/` to chat, manage i
 
 - [Sonar ASO](https://github.com/trysonar/skills) - App Store Optimization for AI agents — keyword research with difficulty & popularity scores, ASO audits, review mining, and revenue estimates for iOS & Google Play via the [Sonar](https://trysonar.app) API. [ClawHub](https://clawhub.ai/petersutarik/sonar-aso) · `openclaw skills install sonar-aso`
 - [MediWise Health Suite](https://github.com/JuneYaooo/mediwise-health-suite) - Family health management skill — health record keeping, diet tracking, weight management, medication reminders, and medical image recognition, all with local SQLite storage for privacy.
+- [stipend](https://github.com/stipend-sh/stipend) - Non-custodial USDC wallet on Base an agent installs by itself, with per-transaction, per-day and per-counterparty spending limits and a destination allowlist enforced in code before signing rather than in a prompt. Also runs as a local stdio MCP server with 7 tools. Python, Apache-2.0, unaudited.
 
 ### Detection & Media Forensics
 


### PR DESCRIPTION
One entry added to **Skills & Plugins → Notable Skills**, same `- [name](url) - description` format as its neighbours. Closest existing entry is ATXP, which also gives an agent a funded USDC wallet on Base.

[stipend](https://github.com/stipend-sh/stipend) ships a `SKILL.md` at the repo root with valid frontmatter (`self_installable: true`, `requires_human: false`), so an agent installs it without a person: no account, no API key, and none needed to be paid either.

What is different from the other wallet entries: the per-transaction, per-day and per-counterparty caps and the destination allowlist are enforced in [`stipend/policy.py`](https://github.com/stipend-sh/stipend/blob/main/stipend/policy.py), on the path between the agent deciding to pay and the transaction being signed. A prompt-level rule sits in the same context window as the text attacking it; this does not. The first payment to any address never paid before needs confirming whatever the size, and no tool reads, exports or derives the private key.

Also runs as a local stdio MCP server (`stipend mcp`, 7 tools) for clients that prefer tools to a shell — happy to move it to the MCP Servers table instead if you would rather list it there; just say which and I will amend rather than adding a second row.

Python, Apache-2.0. **Not audited.**
