### PR TITLE
Add Agent QA MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 
 | Server | Description |
 |--------|-------------|
+| [Agent QA](https://github.com/vostride/agent-qa) | Open-source self-improving QA agent for natural-language web and mobile testing, with persistent test memory, self-healing workflows, and an MCP server available through `agent-qa mcp`. |
 | `https://api.anchorbrowser.io/mcp` | Cloud browser platform for AI agents |
 | [AI Image Generator & Editor — Nanobanana, GPT Image, ComfyUI](https://github.com/jau123/MeiGen-AI-Design-MCP) | Generate professional AI images through a unified interface that routes across multiple providers. 1,300+ curated prompts, style-aware prompt enhancement, and local ComfyUI workflows. |
 | [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) | MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models. Zero API key for first run via free-tier providers (Pollinations, Stable Horde, HuggingFace). MIT licensed. |


### PR DESCRIPTION
## Summary

- add Agent QA to the MCP Servers table
- describe its natural-language web and mobile testing, persistent test memory, and UI-adaptation workflows
- include the exact stdio server command, `agent-qa mcp`

Agent QA is a source-available, self-improving QA agent for software teams. Its MCP server gives agent hosts access to the project's testing workflows without claiming an OpenClaw-specific integration. Current releases use FSL-1.1-ALv2 and convert to Apache-2.0 after two years.

Project: https://github.com/vostride/agent-qa

Disclosure: I am affiliated with Agent QA and Vostride and submitted the official project.

## Validation

- searched the list for an existing Agent QA entry
- verified the MCP command against the public project source
- `git diff --check`
- `npx --yes awesome-lint` was also run; the repository reported pre-existing structural errors across the README

