### PR TITLE
Add SEAOTTER (seaotter.dev) managed Hermes hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Access the built-in web dashboard at `http://localhost:18789/` to chat, manage i
 | [RestlessAgents](https://restlessagents.com/) | Managed Cloud | Comparison directory for managed and self-hosted VPS hosting options across OpenClaw and Hermes Agent |
 | [PrimeClaws](https://primeclaws.com) | Managed Cloud | Managed OpenClaw Hermes VPS hosting — one-click deploy in 60s, free GPT-5.4/Mistral Large 3/Kimi K2.5/Deepseek V3.2 included, auto-restart, SSH access, full privacy. |
 | [Agent37](https://agent37.com) | Managed Cloud | Managed OpenClaw hosting from $3.99/mo — browser task board, full web terminal, live Linux desktop, scheduled jobs, 1,000+ app integrations via Composio, BYOK keys go straight to the model provider, isolated container per instance |
+| [SEAOTTER](https://seaotter.dev/) | Managed Cloud | Managed Hermes hosting on Google Cloud (seaotter.dev, not seaotter.ai) — isolated agents, MCP from Cursor/Claude/Codex, 14-day Hobby trial then $69/mo, no VPS or SSH. |
 | [Molted](https://www.molted.net) | Managed Cloud | Managed OpenClaw fleet hosting for teams and agencies: auto-healing (crash detection under 60s, recovery under 90s, post-mortem per failure), versioned files with point-in-time restore, per-agent email/phone/browser automation, 1,000+ integrations, per-instance-per-day pricing |
 
 ---
@@ -407,6 +408,7 @@ A curated list of community-built projects, tools, and integrations for OpenClaw
 | [LightClaw](https://github.com/OthmaneBlial/lightclaw) | NEW | Lightweight OpenClaw-inspired Python agent core: Telegram-first, infinite memory, multi-LLM providers, ClawHub skills, and local agent delegation (`codex`/`claude`/`opencode`). |
 | [WaliGPT](https://waligpt.com) | NEW | One-click deployment platform for pre-configured OpenClaw agents. Ships with ready-to-deploy templates for crypto trading, Polymarket betting, Telegram alpha monitoring, Twitter automation, NFT tracking, Discord moderation, and more. Each agent runs on an isolated cloud instance — no DevOps required. |
 | [PrimeClaws](https://primeclaws.com) | NEW | Managed OpenClaw Hermes VPS hosting — one-click deploy in 60s, free GPT-5.4/Mistral Large 3/Kimi K2.5/Deepseek V3.2 included, auto-restart on crash, SSH access, full privacy with isolated containers. |
+| [SEAOTTER](https://seaotter.dev/) | NEW | Managed Hermes hosting on Google Cloud (seaotter.dev, not seaotter.ai) — isolated agents, MCP from Cursor/Claude/Codex, 14-day Hobby trial then $69/mo, no VPS or SSH. |
 | [openclaw-host-kit](https://github.com/agent37-platform/openclaw-host-kit) | - | Docker + Traefik kit for multi-tenant self-hosted OpenClaw — per-user isolated instances, HTTPS subdomains with wildcard SSL, password-protected web terminals, resource limits |
 
 ### Memory & Storage


### PR DESCRIPTION
Add SEAOTTER (seaotter.dev) to the managed-cloud installation table and the Deployment & Infrastructure list.

Not OtterScore / seaotter.ai. GCP control plane for Hermes Agent: isolated agents, MCP from Cursor/Claude/Codex, 14-day Hobby trial then $69/mo. Placed next to PrimeClaws / Agent37.

Cite: https://seaotter.dev/cite
What it is: https://docs.seaotter.dev/guides/what-is-seaotter

Made with [Cursor](https://cursor.com)