### PR TITLE
Add SandBase CLI to MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 | Server | Description |
 |--------|-------------|
 | [Agent QA](https://github.com/vostride/agent-qa) | Open-source self-improving QA agent for natural-language web and mobile testing, with persistent test memory, self-healing workflows, and an MCP server available through `agent-qa mcp`. |
+| [SandBase CLI](https://github.com/sandbaseai/cli) | Apache-2.0 local MCP server and installer that connects OpenClaw and 24 other AI clients to 2,000+ models and APIs through six tools, with OAuth and ownership-aware rollback. `npx -y https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz connect` |
 | `https://api.anchorbrowser.io/mcp` | Cloud browser platform for AI agents |
 | [Open Index](https://github.com/DrDroidLab/open-index) | Structured context graph for domain-specific agents with hybrid search, validated read/write MCP tools, and a portable OpenClaw setup skill. |
 | [AI Image Generator & Editor — Nanobanana, GPT Image, ComfyUI](https://github.com/jau123/MeiGen-AI-Design-MCP) | Generate professional AI images through a unified interface that routes across multiple providers. 1,300+ curated prompts, style-aware prompt enhancement, and local ComfyUI workflows. |


### PR DESCRIPTION
## Summary

Add SandBase CLI to the MCP Servers section. It is an Apache-2.0 local MCP server and installer with explicit OpenClaw support.

## Verification

- Project: https://github.com/sandbaseai/cli
- OpenClaw is one of the 25 supported clients
- The README documents the six MCP tools and 2,000+ model/API catalog
- The pinned v0.1.17 release asset is present in GitHub Releases

This PR was prepared with AI assistance and manually checked against the project README, source catalog, license metadata, and release metadata.