### PR TITLE
Add OpenClaw Safe First Run checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ OpenClaw supports the **Model Context Protocol (MCP)** — the open standard ado
 | [Complete Installation Guide](https://www.aifreeapi.com/en/posts/openclaw-installation-guide) | AI Free API | WhatsApp, Telegram, Discord setup |
 | [ClawPath](https://clawpath.dev) | Community | Chinese & English onboarding guide — install, channel, skills, security in 30 min |
 | [Install OpenClaw Guide](https://install-openclaw.net) | install-openclaw.net | Step-by-step VPS & local setup guides, Telegram/VPS install tutorials |
+| [OpenClaw Safe First Run](https://github.com/starqazstar/openclaw-safe-first-run) | GitHub | Safety-first first-session checklist — sender allowlists, credential hygiene, spending caps, risk by route (EN/中文) |
 | [Clawdbot](https://clawdbot.tech/) | Community | Multilingual (EN / 中文 / 日本語 / 한국어 / Español) deployment archive — 30+ guides on Docker, VPS, NAS, security whitepaper, and full rename history |
 
 ### Advanced


### PR DESCRIPTION
Adds [openclaw-safe-first-run](https://github.com/starqazstar/openclaw-safe-first-run) to the Beginner tutorials table — a one-page, safety-first checklist for a first OpenClaw session (allowed-sender scoping, credential hygiene, spending caps, and risk-by-route for local/VPS/hosted), with companion guides in English and Chinese. Independent community resource, MIT licensed.